### PR TITLE
Improve default background color

### DIFF
--- a/objects.php
+++ b/objects.php
@@ -150,7 +150,7 @@ function strip_markups($str) {
 			$this->navbartopiclinks = true;
 			$this->navbarheight = '6em';
 			$this->examplebackground = '#dcdcdc';
-			$this->outputbackground = '#eeee33';
+			$this->outputbackground = '#f2f2f2';
 			$this->shadowbackground = '#777777';
 			$this->stylesheet = 'css.php';
 			$this->logoimage1url = 'http://' . $_SERVER['HTTP_HOST'] . $baseDir;


### PR DESCRIPTION
The default neon yellow-green background color used on listings pages makes the visitor want to claw their eyes out. This PR switches it to the off-white background used for the content area on the php.net front page.